### PR TITLE
Improve download security and config

### DIFF
--- a/telegram_filebot_full (1)/README.md
+++ b/telegram_filebot_full (1)/README.md
@@ -9,6 +9,11 @@ uvicorn app.main:app --reload
 python app/bot.py
 ```
 
+متغیرهای محیطی مهم:
+- `BOT_TOKEN`: توکن ربات تلگرام
+- `API_BASE_URL`: آدرس API بک‌اند برای ربات
+- `DOWNLOAD_DOMAIN`: دامنه‌ای که به کاربر برای دانلود نشان داده می‌شود
+
 ### اجرای با Docker
 ```bash
 docker-compose up --build

--- a/telegram_filebot_full (1)/app/core/config.py
+++ b/telegram_filebot_full (1)/app/core/config.py
@@ -1,0 +1,12 @@
+import os
+
+BOT_TOKEN = os.getenv("BOT_TOKEN", "YOUR_BOT_TOKEN")
+DOWNLOAD_DOMAIN = os.getenv("DOWNLOAD_DOMAIN", "yourdomain.com")
+
+UPLOAD_DIR = os.getenv("UPLOAD_DIR", "./uploads")
+
+BLOCKED_EXTENSIONS = {
+    ".exe", ".bat", ".cmd", ".sh", ".msi", ".dll", ".scr", ".ps1"
+}
+
+ILLEGAL_PATTERNS = ["magnet:", ".torrent"]

--- a/telegram_filebot_full (1)/app/schemas/file.py
+++ b/telegram_filebot_full (1)/app/schemas/file.py
@@ -7,6 +7,7 @@ class FileCreate(BaseModel):
     file_size: int
     is_from_link: Optional[bool] = False
     original_link: Optional[str] = None
+    telegram_file_id: Optional[str] = None
 
 class FileLinkCreate(BaseModel):
     """Schema for creating a file from a remote URL."""

--- a/telegram_filebot_full (1)/app/services/download_worker.py
+++ b/telegram_filebot_full (1)/app/services/download_worker.py
@@ -2,29 +2,65 @@ import requests
 import os
 from datetime import datetime
 from uuid import uuid4
+from app.core import config
 
-UPLOAD_DIR = "./uploads"
+UPLOAD_DIR = config.UPLOAD_DIR
 
-def download_file_from_url(url: str, filename: str) -> str:
+
+def is_illegal_url(url: str) -> bool:
+    url_lower = url.lower()
+    return any(p in url_lower for p in config.ILLEGAL_PATTERNS)
+
+
+def is_blocked_extension(filename: str) -> bool:
+    ext = os.path.splitext(filename)[1].lower()
+    return ext in config.BLOCKED_EXTENSIONS
+
+
+def _prepare_path(filename: str) -> str:
     now = datetime.utcnow()
     date_path = now.strftime("%Y/%m/%d")
     folder_path = os.path.join(UPLOAD_DIR, date_path)
     os.makedirs(folder_path, exist_ok=True)
-
     unique_name = f"{uuid4().hex}_{filename}"
-    full_path = os.path.join(folder_path, unique_name)
+    return os.path.join(folder_path, unique_name)
 
+
+def download_file_from_url(url: str, filename: str) -> str:
+    if is_illegal_url(url) or is_blocked_extension(filename):
+        print("[!] Download blocked due to illegal link or file type")
+        return ""
+    full_path = _prepare_path(filename)
     try:
         response = requests.get(url, stream=True, timeout=30)
         response.raise_for_status()
-
-        with open(full_path, 'wb') as f:
+        with open(full_path, "wb") as f:
             for chunk in response.iter_content(chunk_size=8192):
                 if chunk:
                     f.write(chunk)
-
         print(f"[✔] File downloaded to: {full_path}")
         return full_path
     except Exception as e:
         print(f"[✘] Download failed: {e}")
+        return ""
+
+
+def download_file_from_telegram(file_id: str, filename: str) -> str:
+    if is_blocked_extension(filename):
+        print("[!] Download blocked due to disallowed file type")
+        return ""
+    try:
+        resp = requests.get(
+            f"https://api.telegram.org/bot{config.BOT_TOKEN}/getFile",
+            params={"file_id": file_id},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        file_path = resp.json()["result"]["file_path"]
+        file_url = (
+            f"https://api.telegram.org/file/bot{config.BOT_TOKEN}/{file_path}"
+        )
+        return download_file_from_url(file_url, filename)
+    except Exception as e:
+        print(f"[✘] Telegram download failed: {e}")
         return ""

--- a/telegram_filebot_full (1)/app/services/file_service.py
+++ b/telegram_filebot_full (1)/app/services/file_service.py
@@ -1,8 +1,9 @@
 import os
 from datetime import datetime
 from uuid import uuid4
+from app.core import config
 
-UPLOAD_DIR = "./uploads"
+UPLOAD_DIR = config.UPLOAD_DIR
 
 def save_file_metadata(filename: str) -> str:
     now = datetime.utcnow()


### PR DESCRIPTION
## Summary
- add new config for domain and blocked file types
- implement file validation and Telegram download in worker and API
- update bot to pass Telegram file id and check links
- allow customizing domain via DOWNLOAD_DOMAIN env
- document environment variables in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6847489db6288325b184ffa37b536f56