### PR TITLE
Fix redundant checks

### DIFF
--- a/telegram_filebot_full (1)/app/api/routes_file.py
+++ b/telegram_filebot_full (1)/app/api/routes_file.py
@@ -39,12 +39,6 @@ async def upload_file(file_data: FileCreate, request: Request, db: AsyncSession 
 
     await ensure_not_blocked(user_id)
 
-    await ensure_not_blocked(user_id)
-
-    await ensure_not_blocked(user_id)
-
-    await ensure_not_blocked(user_id)
-
     if is_blocked_extension(file_data.original_file_name):
         raise HTTPException(status_code=400, detail="نوع فایل مجاز نیست")
 
@@ -179,8 +173,6 @@ async def delete_bulk(file_ids: List[str], request: Request, db: AsyncSession = 
     user_id = request.headers.get("X-User-Id")
     if not user_id:
         raise HTTPException(status_code=400, detail="X-User-Id header missing")
-
-    await ensure_not_blocked(user_id)
 
     await ensure_not_blocked(user_id)
     result = await db.execute(select(File).where(File.id.in_(file_ids)))


### PR DESCRIPTION
## Summary
- clean up duplicate `ensure_not_blocked` calls

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684760b9634083259d44a1c2d96d1ba8