### PR TITLE
Fix backend start by adding missing aiosqlite

### DIFF
--- a/telegram_filebot_full (1)/requirements.txt
+++ b/telegram_filebot_full (1)/requirements.txt
@@ -8,3 +8,4 @@ requests
 aiofiles
 psutil
 jinja2
+aiosqlite


### PR DESCRIPTION
## Summary
- add `aiosqlite` to requirements so async SQLite backend works

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_684770e5224083258e34d67a0703d4bc