### PR TITLE
Fix API base URL defaults for Docker use

### DIFF
--- a/telegram_filebot_full (1)/README.md
+++ b/telegram_filebot_full (1)/README.md
@@ -33,7 +33,9 @@ sudo bash setup.sh
 2. فایل `.env` در ریشه پروژه بسازید و مقادیر زیر را وارد کنید یا از اسکریپت `setup.sh` استفاده کنید:
    ```env
    BOT_TOKEN=<توکن ربات تلگرام>
-   API_BASE_URL=http://localhost:8000
+   # آدرس سرویس بک‌اند. در محیط Docker به صورت پیش‌فرض کانتینر `bot`
+   # از طریق نام سرویس `backend` به وب‌سرویس دسترسی دارد.
+   API_BASE_URL=http://backend:8000
    DOWNLOAD_DOMAIN=<دامنه یا IP سرور>
    ADMIN_IDS=<شناسه عددی ادمین‌ها با کاما>
    ADMIN_API_TOKEN=SuperSecretAdminToken123
@@ -62,6 +64,7 @@ python app/bot.py
 متغیرهای محیطی مهم:
 - `BOT_TOKEN`: توکن ربات تلگرام
 - `API_BASE_URL`: آدرس API بک‌اند برای ربات
+  در حالت استفاده از Docker Compose مقدار پیشنهادی `http://backend:8000` است.
 - `DOWNLOAD_DOMAIN`: دامنه‌ای که به کاربر برای دانلود نشان داده می‌شود
 - `SUBSCRIPTION_REMINDER_DAYS`: تعداد روزهای مانده به انقضای اشتراک که یادآوری ارسال می‌شود
 - `REQUIRED_CHANNEL`: شناسه یا یوزرنیم کانالی که عضویت در آن برای استفاده از ربات الزامی است

--- a/telegram_filebot_full (1)/app/bot.py
+++ b/telegram_filebot_full (1)/app/bot.py
@@ -13,7 +13,10 @@ import os
 import requests
 
 BOT_TOKEN = os.getenv("BOT_TOKEN", "YOUR_BOT_TOKEN")
-API_BASE_URL = os.getenv("API_BASE_URL", "http://localhost:8000")
+# When using Docker Compose the backend service is reachable via the
+# 'backend' hostname inside the bot container. Default to that URL so
+# the bot can talk to the API without additional configuration.
+API_BASE_URL = os.getenv("API_BASE_URL", "http://backend:8000")
 ADMIN_IDS = {int(uid) for uid in os.getenv("ADMIN_IDS", "").split(",") if uid}
 REQUIRED_CHANNEL = os.getenv("REQUIRED_CHANNEL")
 BOT_PAUSED = False

--- a/telegram_filebot_full (1)/setup.sh
+++ b/telegram_filebot_full (1)/setup.sh
@@ -16,13 +16,16 @@ systemctl enable --now docker
 # Ask for configuration
 read -rp "Enter Telegram Bot Token: " BOT_TOKEN
 read -rp "Enter download domain (e.g. example.com): " DOWNLOAD_DOMAIN
-read -rp "Enter API base URL [http://localhost:8000]: " API_BASE_URL
+read -rp "Enter API base URL [http://backend:8000]: " API_BASE_URL
 read -rp "Enter admin IDs separated by comma: " ADMIN_IDS
 read -rp "Enter admin API token: " ADMIN_API_TOKEN
 read -rp "Enter subscription reminder days [3]: " SUBSCRIPTION_REMINDER_DAYS
 read -rp "Enter required channel username or ID (leave blank if none): " REQUIRED_CHANNEL
 
-API_BASE_URL=${API_BASE_URL:-http://localhost:8000}
+# When running the services with Docker Compose the backend container is
+# accessible via the hostname 'backend'. Use that as the default API base
+# URL so the bot can connect without extra configuration.
+API_BASE_URL=${API_BASE_URL:-http://backend:8000}
 SUBSCRIPTION_REMINDER_DAYS=${SUBSCRIPTION_REMINDER_DAYS:-3}
 
 cat > .env <<ENV


### PR DESCRIPTION
## Summary
- default bot's API base URL to `http://backend:8000`
- update README instructions for Docker usage
- adjust setup script default for API base URL

## Testing
- `bash -n telegram_filebot_full\ \(1\)/setup.sh`
- `python -m ast` compile all python files

------
https://chatgpt.com/codex/tasks/task_b_68477bff96d48325bae87e9c49c817e9