### PR TITLE
Fix subscription checks to reuse DB session

### DIFF
--- a/telegram_filebot_full (1)/app/api/routes_file.py
+++ b/telegram_filebot_full (1)/app/api/routes_file.py
@@ -43,8 +43,8 @@ async def upload_file(file_data: FileCreate, request: Request, db: AsyncSession 
         raise HTTPException(status_code=400, detail="نوع فایل مجاز نیست")
 
     # Subscription and quota checks before downloading
-    await check_active_subscription(user_id)
-    await check_user_limits(user_id, file_data.file_size)
+    await check_active_subscription(user_id, db)
+    await check_user_limits(user_id, file_data.file_size, db)
 
     if file_data.telegram_file_id:
         storage_path = download_file_from_telegram(
@@ -95,8 +95,8 @@ async def upload_from_link(data: FileLinkCreate, request: Request, db: AsyncSess
         raise HTTPException(status_code=400, detail="نوع فایل مجاز نیست")
 
     remote_size = get_remote_file_size(data.url)
-    await check_active_subscription(user_id)
-    await check_user_limits(user_id, remote_size)
+    await check_active_subscription(user_id, db)
+    await check_user_limits(user_id, remote_size, db)
 
     path = download_file_from_url(data.url, file_name)
     if not path:


### PR DESCRIPTION
## Summary
- reuse existing DB session when verifying subscriptions and quota
- update file upload routes to pass session

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68489f0686848325b950efdcfd428b09