### PR TITLE
Implement API root endpoint

### DIFF
--- a/telegram_filebot_full (1)/app/main.py
+++ b/telegram_filebot_full (1)/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from app.core.db import engine, Base
 from app.api import routes_user, routes_file, routes_admin
@@ -21,3 +22,9 @@ async def on_startup() -> None:
 app.include_router(routes_user.router, prefix="/user", tags=["User"])
 app.include_router(routes_file.router, prefix="/file", tags=["File"])
 app.include_router(routes_admin.router, prefix="/admin", tags=["Admin"])
+
+
+@app.get("/")
+async def read_root() -> JSONResponse:
+    """Simple welcome endpoint for the API root."""
+    return JSONResponse({"message": "Telegram FileBot API"})


### PR DESCRIPTION
## Summary
- handle the `/` URL by adding a simple root endpoint

## Testing
- `python -m py_compile app/main.py`
- `find app -name '*.py' -print0 | xargs -0 python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_b_6848a196cb3c8325a63ccc4d23742467