### PR TITLE
Improve admin APIs

### DIFF
--- a/telegram_filebot_full (1)/requirements.txt
+++ b/telegram_filebot_full (1)/requirements.txt
@@ -5,6 +5,8 @@ asyncpg
 pydantic
 python-telegram-bot==20.3
 requests
+aiohttp
+slowapi
 aiofiles
 psutil
 jinja2


### PR DESCRIPTION
## Summary
- reorganize imports and add logging to admin routes
- add pydantic model for updating settings safely
- improve error handling for file deletion and plan creation
- add async broadcast with rate limiting
- implement pagination for user listing
- update requirements for aiohttp and slowapi

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6849590711dc8325b64d56799d5504cf