### PR TITLE
Improve user API security and validation

### DIFF
--- a/telegram_filebot_full (1)/app/api/routes_user.py
+++ b/telegram_filebot_full (1)/app/api/routes_user.py
@@ -1,87 +1,207 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.security import HTTPBearer
+from slowapi import Limiter
+from slowapi.util import get_remote_address
 from app.core.user_guard import ensure_not_blocked
+from app.core.auth import verify_user_token
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 from sqlalchemy.orm import selectinload
 from app.schemas.user import UserCreate, UserOut
+from app.schemas.subscription import UserSubscriptionDetail, SubscriptionPlanInfo
 from app.models.user import User
 from app.models.subscription import SubscriptionPlan
 from app.models.user_subscription import UserSubscription
+from app.models.file import File
 from datetime import datetime, timedelta
+from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
+import uuid
+import logging
+import time
+from functools import wraps
+from typing import Optional
 from app.core.db import async_session
 
 router = APIRouter()
+limiter = Limiter(key_func=get_remote_address)
+router.state.limiter = limiter
+security = HTTPBearer()
+logger = logging.getLogger(__name__)
+
+
+def log_endpoint_access(func):
+    @wraps(func)
+    async def wrapper(*args, **kwargs):
+        start_time = time.time()
+        current_user = kwargs.get("current_user")
+        user_info = f"user_id={current_user.id}" if current_user else "anonymous"
+        logger.info(f"Endpoint access: {func.__name__} - {user_info}")
+        try:
+            result = await func(*args, **kwargs)
+            logger.info(
+                f"Endpoint success: {func.__name__} - {round(time.time() - start_time, 3)}s"
+            )
+            return result
+        except Exception as e:
+            logger.error(
+                f"Endpoint error: {func.__name__} - {e} - {round(time.time() - start_time, 3)}s"
+            )
+            raise
+
+    return wrapper
 
 async def get_db():
     async with async_session() as session:
         yield session
 
-@router.post("/register", response_model=UserOut)
-async def register_user(user: UserCreate, db: AsyncSession = Depends(get_db)):
-    result = await db.execute(select(User).where(User.telegram_id == user.telegram_id))
-    existing_user = result.scalars().first()
-    if existing_user:
-        return existing_user
 
-    new_user = User(
-        telegram_id=user.telegram_id,
-        username=user.username,
-        full_name=user.full_name,
+async def get_authenticated_user(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    token: Optional[str] = Depends(security),
+) -> User:
+    if not token:
+        raise HTTPException(
+            status_code=401,
+            detail="Authentication required",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    user_id = await verify_user_token(token.credentials, db)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalars().first()
+    if not user:
+        raise HTTPException(status_code=401, detail="User not found")
+
+    await ensure_not_blocked(user.id)
+    return user
+
+
+async def create_default_free_plan(db: AsyncSession) -> SubscriptionPlan:
+    free_plan = SubscriptionPlan(
+        id=str(uuid.uuid4()),
+        name="Free",
+        max_storage_mb=100,
+        max_files=10,
+        expiry_days=3650,
+        price=0,
+        is_active=True,
     )
-    db.add(new_user)
-    await db.commit()
-    await db.refresh(new_user)
+    db.add(free_plan)
+    await db.flush()
+    return free_plan
 
+
+async def create_free_subscription(db: AsyncSession, user_id: str):
     result = await db.execute(
         select(SubscriptionPlan).where(SubscriptionPlan.name == "Free")
     )
     free_plan = result.scalars().first()
     if not free_plan:
-        free_plan = SubscriptionPlan(
-            name="Free",
-            max_storage_mb=100,
-            max_files=10,
-            expiry_days=3650,
-            price=0,
-            is_active=True,
-        )
-        db.add(free_plan)
-        await db.commit()
-        await db.refresh(free_plan)
+        free_plan = await create_default_free_plan(db)
 
-    sub = UserSubscription(
-        user_id=new_user.id,
+    subscription = UserSubscription(
+        id=str(uuid.uuid4()),
+        user_id=user_id,
         plan_id=free_plan.id,
         start_date=datetime.utcnow(),
         end_date=datetime.utcnow() + timedelta(days=free_plan.expiry_days),
         is_active=True,
     )
-    db.add(sub)
-    await db.commit()
-
-    return new_user
+    db.add(subscription)
 
 
-@router.get("/subscription")
-async def get_my_subscription(request: Request, db: AsyncSession = Depends(get_db)):
-    user_id = request.headers.get("X-User-Id")
-    if not user_id:
-        raise HTTPException(status_code=400, detail="X-User-Id header missing")
+async def get_user_storage_stats(db: AsyncSession, user_id: str) -> dict:
+    result = await db.execute(
+        select(
+            func.coalesce(func.sum(File.file_size), 0).label("total_size"),
+            func.count(File.id).label("files_count"),
+        ).where(File.user_id == user_id)
+    )
+    stats = result.first()
+    return {
+        "storage_mb": round(stats.total_size / (1024 * 1024), 2) if stats.total_size else 0,
+        "files_count": stats.files_count or 0,
+    }
 
-    await ensure_not_blocked(user_id)
+@router.post("/register", response_model=UserOut)
+@limiter.limit("3/minute")
+@log_endpoint_access
+async def register_user(
+    request: Request,
+    user_data: UserCreate,
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        async with db.begin():
+            result = await db.execute(
+                select(User)
+                .where(User.telegram_id == user_data.telegram_id)
+                .with_for_update()
+            )
+            existing_user = result.scalars().first()
+            if existing_user:
+                logger.info(f"User already exists: {user_data.telegram_id}")
+                return existing_user
 
+            new_user = User(
+                id=str(uuid.uuid4()),
+                telegram_id=user_data.telegram_id,
+                username=user_data.username,
+                full_name=user_data.full_name,
+            )
+            db.add(new_user)
+            await db.flush()
+
+            await create_free_subscription(db, new_user.id)
+
+            logger.info(f"New user registered: {new_user.id}")
+            return new_user
+    except IntegrityError:
+        await db.rollback()
+        logger.warning(f"Duplicate user registration attempt: {user_data.telegram_id}")
+        result = await db.execute(select(User).where(User.telegram_id == user_data.telegram_id))
+        return result.scalars().first()
+    except Exception as e:
+        await db.rollback()
+        logger.error(f"User registration failed: {e}")
+        raise HTTPException(status_code=500, detail="Registration failed. Please try again.")
+
+
+@router.get("/subscription", response_model=UserSubscriptionDetail)
+@limiter.limit("30/minute")
+@log_endpoint_access
+async def get_my_subscription(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_authenticated_user),
+):
     result = await db.execute(
         select(UserSubscription)
         .options(selectinload(UserSubscription.plan))
-        .where(UserSubscription.user_id == user_id, UserSubscription.is_active == True)
+        .where(
+            UserSubscription.user_id == current_user.id,
+            UserSubscription.is_active == True,
+        )
     )
-    sub = result.scalars().first()
-    if not sub:
-        raise HTTPException(status_code=404, detail="Subscription not found")
+    subscription = result.scalars().first()
+    if not subscription:
+        raise HTTPException(status_code=404, detail="هیچ اشتراک فعالی یافت نشد")
 
-    plan = sub.plan
-    return {
-        "plan_name": plan.name,
-        "end_date": sub.end_date,
-        "is_active": sub.is_active,
-    }
+    days_remaining = max(0, (subscription.end_date - datetime.utcnow()).days)
+    storage_stats = await get_user_storage_stats(db, current_user.id)
+
+    return UserSubscriptionDetail(
+        id=subscription.id,
+        plan=subscription.plan,
+        start_date=subscription.start_date,
+        end_date=subscription.end_date,
+        is_active=subscription.is_active,
+        days_remaining=days_remaining,
+        storage_used_mb=storage_stats["storage_mb"],
+        files_count=storage_stats["files_count"],
+    )

--- a/telegram_filebot_full (1)/app/schemas/subscription.py
+++ b/telegram_filebot_full (1)/app/schemas/subscription.py
@@ -41,3 +41,27 @@ class SubscriptionPlanOut(BaseModel):
     is_active: bool
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class SubscriptionPlanInfo(BaseModel):
+    id: str
+    name: str
+    max_storage_mb: int
+    max_files: int
+    expiry_days: Optional[int]
+    price: float
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class UserSubscriptionDetail(BaseModel):
+    id: str
+    plan: SubscriptionPlanInfo
+    start_date: datetime
+    end_date: datetime
+    is_active: bool
+    days_remaining: int
+    storage_used_mb: Optional[int] = 0
+    files_count: Optional[int] = 0
+
+    model_config = ConfigDict(from_attributes=True)

--- a/telegram_filebot_full (1)/app/schemas/user.py
+++ b/telegram_filebot_full (1)/app/schemas/user.py
@@ -1,10 +1,28 @@
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field, validator
 from typing import Optional
 
 class UserCreate(BaseModel):
-    telegram_id: int
-    username: Optional[str] = None
-    full_name: Optional[str] = None
+    telegram_id: int = Field(..., gt=0)
+    username: Optional[str] = Field(None, max_length=50)
+    full_name: str = Field(..., min_length=1, max_length=100)
+
+    @validator("telegram_id")
+    def validate_telegram_id(cls, v):
+        if v < 0 or v > 9999999999:
+            raise ValueError("شناسه تلگرام نامعتبر است")
+        return v
+
+    @validator("username")
+    def validate_username(cls, v):
+        if v and not v.replace("_", "").isalnum():
+            raise ValueError("نام کاربری فقط می‌تواند شامل حروف، اعداد و _ باشد")
+        return v.lower() if v else v
+
+    @validator("full_name")
+    def validate_full_name(cls, v):
+        if not v.strip():
+            raise ValueError("نام کامل نمی‌تواند خالی باشد")
+        return v.strip()
 
 class UserOut(BaseModel):
     id: str


### PR DESCRIPTION
## Summary
- add strict validation for `UserCreate`
- extend subscription schemas with rich output models
- overhaul `/user/register` with race-condition safe logic
- secure `/user/subscription` with token auth
- add rate limiting and logging for user endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68495fdc8bd88325b2202cf939ba1894